### PR TITLE
Make sure alert view is dismissed before the block runs

### DIFF
--- a/Classes/BlockAdditions/PSAlertView.m
+++ b/Classes/BlockAdditions/PSAlertView.m
@@ -67,7 +67,7 @@
 #pragma mark -
 #pragma mark UIAlertViewDelegate
 
-- (void)alertView:(UIAlertView *)alertView clickedButtonAtIndex:(NSInteger)buttonIndex {
+- (void)alertView:(UIAlertView *)alertView didDismissWithButtonIndex:(NSInteger)buttonIndex {
   /* Run the button's block */
   if (buttonIndex >= 0 && buttonIndex < [_blocks count]) {
     void (^b)() = [_blocks objectAtIndex: buttonIndex];


### PR DESCRIPTION
Hi Peter,

I added your PSAlertView to a project of mine and had troubles opening a new view (part of a third-party API) from the "OK" button block because the alert view was not dismissed yet when the block was called. (I guess the alert view was incorrectly used as the parent view for the new view.)

While this may be a problem of the third-party API, I still think it is cleaner to use alertView:didDismissWithButtonIndex: instead of alertView:clickedButtonAtIndex:.

Cheers,
Christoph
