### PR TITLE
Revert premature podspec version bump

### DIFF
--- a/PSAlertView.podspec
+++ b/PSAlertView.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name           = 'PSAlertView'
-  s.version        = '0.0.2'
+  s.version        = '0.0.1'
   s.summary        = "Modern block-based wrappers for UIAlertView and UIActionSheet."
   s.homepage       = "https://github.com/steipete/PSAlertView"
   s.author         = { 'Peter Steinberger' => 'steipete@gmail.com' }


### PR DESCRIPTION
Sorry to hit you again with this, @steipete!

Cocoapods spec repo maintainers requested that the version number 
not be incremented.  They prefer to leave the version number at 0.0.1
for all projects that don't have their own semantic version number
scheme backed by tags within the project's github repo. 

Leaving the version number at 0.0.1 here is fine since the latest change 
was limited to removing an unnecessary platform restriction in the 
podspec.

Better still (from the cocoapod perspective) would be for an official
semantic version to be declared (and tagged) in the repo.  Then
the podspec could reference this tag and have a blessed version
number as opposed to the rather arbitrary 0.0.1 currently used.
