### PR TITLE
Update podspec to use tag

### DIFF
--- a/PSAlertView.podspec
+++ b/PSAlertView.podspec
@@ -4,7 +4,7 @@ Pod::Spec.new do |s|
   s.summary        = "Modern block-based wrappers for UIAlertView and UIActionSheet."
   s.homepage       = "https://github.com/steipete/PSAlertView"
   s.author         = { 'Peter Steinberger' => 'steipete@gmail.com' }
-  s.source         = { :git => 'https://github.com/steipete/PSAlertView.git', :commit => 'bcc4316bbc6a82941b8661b3909992c317141355' }
+  s.source         = { :git => 'https://github.com/steipete/PSAlertView.git', :tag => '1.1' }
   s.platform       = :ios
   s.requires_arc   = true
   s.source_files   = '*.{h,m}'


### PR DESCRIPTION
The current podspec references a specific commit - instead we want it to reference the latest stable tag (1.1).  Just one more hurdle and the podspec stuff is good-to-go.
