### PR TITLE
Replace deprecated drawInRect: method on iOS 7 and higher

### DIFF
--- a/PSPDFAlertView.m
+++ b/PSPDFAlertView.m
@@ -385,7 +385,14 @@
                 if (self.buttonFont)
                     buttonFont = self.buttonFont;
 
-#if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_6_0
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_7_0
+                NSMutableParagraphStyle *paragraphStyle = [[NSParagraphStyle defaultParagraphStyle] mutableCopy];
+                paragraphStyle.lineBreakMode = NSLineBreakByClipping;
+                paragraphStyle.alignment = NSTextAlignmentCenter;
+
+                NSDictionary *attributes = @{NSFontAttributeName : buttonFont, NSParagraphStyleAttributeName : paragraphStyle};
+                [button.titleLabel.text drawInRect:CGRectMake(button.frame.origin.x, button.frame.origin.y+10, button.frame.size.width, button.frame.size.height) withAttributes:attributes];
+#elif __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_6_0
                 [button.titleLabel.text drawInRect:CGRectMake(button.frame.origin.x, button.frame.origin.y+10, button.frame.size.width, button.frame.size.height) withFont:buttonFont lineBreakMode:NSLineBreakByClipping alignment:NSTextAlignmentCenter];
 #else
                 [button.titleLabel.text drawInRect:CGRectMake(button.frame.origin.x, button.frame.origin.y+10, button.frame.size.width, button.frame.size.height) withFont:buttonFont lineBreakMode:UILineBreakModeClip alignment:UITextAlignmentCenter];


### PR DESCRIPTION
This has been bugging me for a little while — sorry I didn't send through a PR sooner.
