### PR TITLE
Properly initialises the class when using UIAlertView’s designated initialiser

### DIFF
--- a/PSPDFAlertView.m
+++ b/PSPDFAlertView.m
@@ -52,15 +52,19 @@
 ///////////////////////////////////////////////////////////////////////////////////////////
 #pragma mark - NSObject
 
+- (id)init {
+    if ((self = [super init])) {
+        _blocks = [[NSMutableArray alloc] init];
+    }
+    return self;
+}
+
 - (id)initWithTitle:(NSString *)title {
     return self = [self initWithTitle:title message:nil];
 }
 
 - (id)initWithTitle:(NSString *)title message:(NSString *)message {
-    if ((self = [super initWithTitle:title message:message delegate:self cancelButtonTitle:nil otherButtonTitles:nil])) {
-        _blocks = [[NSMutableArray alloc] init];
-    }
-    return self;
+    return self = [super initWithTitle:title message:message delegate:self cancelButtonTitle:nil otherButtonTitles:nil];
 }
 
 - (void)dealloc {


### PR DESCRIPTION
Fixes #8 — the UIAlertView designated initialiser expects the `otherButtonTitles` parameter to be non-nil before the `- (BOOL)alertViewShouldEnableFirstOtherButton:(UIAlertView *)alertView` delegate method will be called.

I've also filed a radar: http://openradar.appspot.com/radar?id=6189750637559808
