### PR TITLE
Added basic init for action sheet.

### DIFF
--- a/PSPDFActionSheet.h
+++ b/PSPDFActionSheet.h
@@ -16,6 +16,9 @@
 /// Default initializer.
 - (id)initWithTitle:(NSString *)title;
 
+/// Basic init.
+- (id)init;
+
 /// @name Adding Buttons
 
 /// Adds a cancel button. Use only once.

--- a/PSPDFActionSheet.m
+++ b/PSPDFActionSheet.m
@@ -29,6 +29,16 @@
     return self;
 }
 
+- (id)init {
+    self = [super init];
+    if (self) {
+        
+        // Create the blocks storage for handling all button actions
+        _blocks = [[NSMutableArray alloc] init];
+    }
+    return self;
+}
+
 - (void)dealloc {
     self.delegate = nil;
 }


### PR DESCRIPTION
There is a need for the basic init in the Action Sheet (Alert too probably). The blocks array is not initialized on a basic alloc/init and can be confusing to users when the blocks are not called. I realize the initWithTitle is the preferred method of use, but there are cases when you don't want a title and a basic alloc/init will suffice.
