### PR TITLE
Added delegate handling for willPresentActionSheet

### DIFF
--- a/PSPDFActionSheet.m
+++ b/PSPDFActionSheet.m
@@ -160,6 +160,13 @@
 }
 
 // Before animation and hiding view.
+- (void)willPresentActionSheet:(UIActionSheet *)actionSheet {
+    id<UIActionSheetDelegate> delegate = self.realDelegate;
+    if ([delegate respondsToSelector:_cmd]) {
+        [delegate willPresentActionSheet:actionSheet];
+    }
+}
+
 - (void)actionSheet:(UIActionSheet *)actionSheet willDismissWithButtonIndex:(NSInteger)buttonIndex {
     [self _callBlocks:self.willDismissBlocks withButtonIndex:buttonIndex];
     self.willDismissBlocks = nil;


### PR DESCRIPTION
When the project was updated to 2.0, the delegate handling for willPresentActionSheet was removed and no longer allows this delegate to be called. Added this delegate method back in so the delegate will get called.
