### PR TITLE
PSPDFActionSheet: set default value for `allowsTapToDismiss` property

### DIFF
--- a/PSPDFActionSheet.m
+++ b/PSPDFActionSheet.m
@@ -31,7 +31,10 @@
 }
 
 - (id)initWithTitle:(NSString *)title {
-    return self = [super initWithTitle:title delegate:self cancelButtonTitle:nil destructiveButtonTitle:nil otherButtonTitles:nil];
+    if ((self = [super initWithTitle:title delegate:self cancelButtonTitle:nil destructiveButtonTitle:nil otherButtonTitles:nil])) {
+        _allowsTapToDismiss = YES;
+    }
+    return self;
 }
 
 - (void)dealloc {


### PR DESCRIPTION
> /// Allows to be dismissed by tapping outside? Defaults to YES (UIActionSheet default)
> @property (nonatomic, assign) BOOL allowsTapToDismiss;

`allowsTapToDismiss` should default to `YES` as documented.
